### PR TITLE
Made library compatible with both Unix and Windows versions of gpg-agent

### DIFF
--- a/gpgagent.go
+++ b/gpgagent.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"io"
-	"net"
 	"net/url"
 	"os"
 	"strings"
@@ -41,30 +40,6 @@ var (
 	ErrNoData  = errors.New("GPG_ERR_NO_DATA cache miss")
 	ErrCancel  = errors.New("gpgagent: Cancel")
 )
-
-// NewGpgAgentConn connects to the GPG Agent as described in the
-// GPG_AGENT_INFO environment variable.
-func NewGpgAgentConn() (*Conn, error) {
-	sp := strings.SplitN(os.Getenv("GPG_AGENT_INFO"), ":", 3)
-	if len(sp) == 0 || len(sp[0]) == 0 {
-		return nil, ErrNoAgent
-	}
-	addr := &net.UnixAddr{Net: "unix", Name: sp[0]}
-	uc, err := net.DialUnix("unix", nil, addr)
-	if err != nil {
-		return nil, err
-	}
-	br := bufio.NewReader(uc)
-	lineb, err := br.ReadSlice('\n')
-	if err != nil {
-		return nil, err
-	}
-	line := string(lineb)
-	if !strings.HasPrefix(line, "OK") {
-		return nil, fmt.Errorf("gpgagent: didn't get OK; got %q", line)
-	}
-	return &Conn{uc, br}, nil
-}
 
 func (c *Conn) Close() error {
 	c.br = nil

--- a/gpgagent_test.go
+++ b/gpgagent_test.go
@@ -37,7 +37,7 @@ func TestPrompt(t *testing.T) {
 		Desc:     "Type 'foo' for testing",
 		Error:    "seriously, or I'll be an error.",
 		Prompt:   "foo",
-		CacheKey: fmt.Sprintf("gpgagent_test-cachekey-%d", time.Now()),
+		CacheKey: fmt.Sprintf("gpgagent_test-cachekey-%s", time.Now()),
 	}
 	s1, err := conn.GetPassphrase(req)
 	if err != nil {
@@ -73,7 +73,7 @@ func TestPrompt(t *testing.T) {
 		Desc:     "Press Cancel for testing",
 		Error:    "seriously, or I'll be an error.",
 		Prompt:   "cancel!",
-		CacheKey: fmt.Sprintf("gpgagent_test-cachekey-%d", time.Now()),
+		CacheKey: fmt.Sprintf("gpgagent_test-cachekey-%s", time.Now()),
 	})
 	if err != ErrCancel {
 		t.Errorf("expected cancel, got %q, %v", s4, err)

--- a/gpgagent_unix.go
+++ b/gpgagent_unix.go
@@ -1,0 +1,35 @@
+// +build !windows
+
+package gpgagent
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+)
+
+// NewGpgAgentConn connects to the GPG Agent as described in the
+// GPG_AGENT_INFO environment variable.
+func NewGpgAgentConn() (*Conn, error) {
+	sp := strings.SplitN(os.Getenv("GPG_AGENT_INFO"), ":", 3)
+	if len(sp) == 0 || len(sp[0]) == 0 {
+		return nil, ErrNoAgent
+	}
+	addr := &net.UnixAddr{Net: "unix", Name: sp[0]}
+	uc, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		return nil, err
+	}
+	br := bufio.NewReader(uc)
+	lineb, err := br.ReadSlice('\n')
+	if err != nil {
+		return nil, err
+	}
+	line := string(lineb)
+	if !strings.HasPrefix(line, "OK") {
+		return nil, fmt.Errorf("gpgagent: didn't get OK; got %q", line)
+	}
+	return &Conn{uc, br}, nil
+}

--- a/gpgagent_windows.go
+++ b/gpgagent_windows.go
@@ -1,0 +1,65 @@
+// +build windows
+
+package gpgagent
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os/exec"
+	"strings"
+)
+
+// NewGpgAgentConn connects to the GPG Agent using the TCP socket on Windows that
+// emulates the Unix socket.
+func NewGpgAgentConn() (*Conn, error) {
+	//In testing, this is the only reliable way I've found to get the path to the socket/nonce details
+	agentOut, _ := exec.Command("gpg-connect-agent", "getinfo socket_name", "/bye").CombinedOutput()
+	firstLine := strings.Split(string(agentOut), "\n")[0]
+	if len(firstLine) < 3 {
+		return nil, ErrNoAgent
+	}
+
+	//The output from gpg-connect-agent is a bit messy and needs cleaning up
+	socketPath := strings.TrimSpace(firstLine[2:])
+	sc, err := ioutil.ReadFile(socketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	//The socket file is a port number, 0x0A, then a 16-bit nonce. This will extract
+	//the port number and the nonce, and make sure that everything matches correctly.
+	splitOn, _ := hex.DecodeString("0a")
+	socketParts := bytes.SplitN(sc, splitOn, 2)
+	if len(socketParts) != 2 {
+		return nil, fmt.Errorf("Invalid socket file")
+	}
+	port := string(socketParts[0])
+	nonce := socketParts[1]
+	if len(nonce) != 16 {
+		return nil, fmt.Errorf("Invalid socket file nonce")
+	}
+
+	//We have our socket number and nonce, so we can dial to localhost:port
+	connAddr := fmt.Sprintf("127.0.0.1:%s", port)
+	uc, err := net.Dial("tcp", connAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	//Write the nonce to the socket and we should get our OK reply
+	uc.Write(nonce)
+	br := bufio.NewReader(uc)
+	lineb, err := br.ReadSlice('\n')
+	if err != nil {
+		return nil, err
+	}
+	line := string(lineb)
+	if !strings.HasPrefix(line, "OK") {
+		return nil, fmt.Errorf("gpgagent: didn't get OK; got %q", line)
+	}
+	return &Conn{uc, br}, nil
+}


### PR DESCRIPTION
Honestly this took me about an hour to do this morning, so it might need a bit more looking over. But essentially this adds support for Windows gpg-agent into this library.

I added the support by using compile-time flags in `gpgagent_unix.go` and `gpgagent_windows.go` so that a different version of `NewGpgAgentConn` gets compiled in depending on which platform you compile with.

Because Windows does not have Unix sockets, and gpg-agent doesn't use named pipes (rather it binds a localhost TCP socket), the Windows version:

- Discovers the path to the socket file (environment variables are not reliable on Windows)
- Opens the socket file
- Reads the port number and the nonce out of the socket file
- Initiates a TCP connection instead of a Unix connection to `127.0.0.1:port`
- Writes the nonce to the port
- Returns the TCP socket

I've only done limited testing, but it works great in the examples I've tried.